### PR TITLE
Fail fast on misconfigured models + document non-Anthropic providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,38 @@ Full-repo scan (sonnet recommended, ~10 min, ~$4):
 python scripts/security-review-action.py --repo-dir . --full-repo --model sonnet
 ```
 
+On a medium-to-large monorepo, `--full-repo` pushes a single review call past
+typical per-request limits. Start with `--diff-base main` (or point
+`--repo-dir` at a subdirectory) before attempting a whole-repo sweep.
+
+### Non-Anthropic providers (Bedrock, Vertex)
+
+Soundcheck shells out to `claude -p --model <X>`, so whatever model string
+the `claude` CLI accepts, Soundcheck accepts. For AWS Bedrock or Google
+Vertex, the model argument alone isn't enough — the CLI needs
+provider-selection env vars before it will route the call correctly:
+
+```bash
+# Bedrock
+export CLAUDE_CODE_USE_BEDROCK=1
+export AWS_REGION=us-east-1
+# plus AWS credentials (SSO, IAM role, or access keys)
+
+python scripts/security-review-action.py --repo-dir . --diff-base main \
+  --model arn:aws:bedrock:us-east-1:...:application-inference-profile/...
+```
+
+```bash
+# Vertex
+export CLAUDE_CODE_USE_VERTEX=1
+export CLOUD_ML_REGION=us-east5
+export ANTHROPIC_VERTEX_PROJECT_ID=your-gcp-project
+```
+
+Without those env vars, `claude -p --model <ARN>` will hang or silently fail
+and Soundcheck will surface a timeout. The script runs a short preflight
+call before the real review to catch this class of misconfiguration fast.
+
 ---
 
 ## Install

--- a/scripts/_claude_cli.py
+++ b/scripts/_claude_cli.py
@@ -88,17 +88,43 @@ def run_claude(
     if max_budget_usd > 0:
         cmd.extend(["--max-budget-usd", str(max_budget_usd)])
 
-    result = subprocess.run(
-        cmd,
-        input=user_prompt,
-        capture_output=True,
-        text=True,
-        timeout=timeout,
-        cwd=cwd,
-    )
+    try:
+        result = subprocess.run(
+            cmd,
+            input=user_prompt,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            cwd=cwd,
+        )
+    except subprocess.TimeoutExpired as exc:
+        partial = (exc.stderr or b"").decode("utf-8", errors="replace")[-500:]
+        suffix = f"; last stderr: {partial.strip()}" if partial.strip() else ""
+        raise ClaudeCLIError(
+            f"claude timed out after {timeout}s with model={model!r}{suffix}"
+        ) from exc
     if result.returncode != 0:
         raise ClaudeCLIError(
             f"claude exited with code {result.returncode}: "
             f"{result.stderr[:500]}"
         )
     return result.stdout.strip() if result.stdout else ""
+
+
+def preflight_claude(model: str, *, timeout: int = 30) -> None:
+    """Cheap liveness check for the `claude` CLI + model combo.
+
+    Runs a zero-tool prompt with a short timeout to surface auth and
+    model-routing failures (e.g. a Bedrock ARN without the matching
+    env vars) in seconds instead of waiting for the real review to
+    blow the main timeout. Raises ``ClaudeCLIError`` on any failure;
+    succeeds silently.
+    """
+    run_claude(
+        "Reply with the single word: ok",
+        "You are a liveness check. Reply with the single word 'ok'.",
+        model=model,
+        disable_tools=True,
+        max_budget_usd=0.25,
+        timeout=timeout,
+    )

--- a/scripts/security-review-action.py
+++ b/scripts/security-review-action.py
@@ -34,7 +34,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
-from _claude_cli import ClaudeCLIError, run_claude  # noqa: E402
+from _claude_cli import ClaudeCLIError, preflight_claude, run_claude  # noqa: E402
 
 SCRIPT_DIR = Path(__file__).parent
 SKILLS_DIR = SCRIPT_DIR.parent / ".claude" / "skills"
@@ -290,6 +290,25 @@ def main() -> int:
 
     print(f"Running security review on {repo_dir} ({mode}) "
           f"model={args.model} budget=${args.max_budget_usd}...")
+
+    # Cheap liveness check before the real run. Catches misconfigured
+    # third-party providers (Bedrock/Vertex inference profiles without
+    # the matching env vars, etc.) in seconds instead of after the full
+    # timeout with no visible output. See issue #10.
+    try:
+        preflight_claude(args.model)
+    except ClaudeCLIError as exc:
+        print(
+            f"ERROR: claude preflight failed for model={args.model!r}: "
+            f"{exc}\n"
+            "Hint: soundcheck shells out to `claude -p --model <X>`, so "
+            "--model accepts whatever the claude CLI accepts. For "
+            "Bedrock/Vertex set CLAUDE_CODE_USE_BEDROCK=1 (or "
+            "CLAUDE_CODE_USE_VERTEX=1) and the matching provider "
+            "credentials in your environment.",
+            file=sys.stderr,
+        )
+        return 2
 
     try:
         response = run_claude(


### PR DESCRIPTION
## Summary

- `_claude_cli.run_claude` now catches `subprocess.TimeoutExpired` and raises `ClaudeCLIError` with the model and a trailing slice of stderr — replaces the raw Python traceback the user saw in #10.
- New `preflight_claude` helper runs a zero-tool liveness ping (30s timeout, \$0.25 budget).
- `scripts/security-review-action.py` calls `preflight_claude` before the real review, so a misconfigured model/provider combo fails in seconds with a pointer to the `CLAUDE_CODE_USE_BEDROCK` / `CLAUDE_CODE_USE_VERTEX` env vars instead of after the full timeout.
- README gains a **Non-Anthropic providers (Bedrock, Vertex)** section with the env-var matrix, and a note that `--full-repo` on a medium-to-large monorepo pushes a single review call past typical per-request limits (start with `--diff-base main`).

Closes #10.

## Test plan

- [x] `python scripts/validate-skills.py` — 45/45 pass
- [x] `python scripts/security-review-action.py --help` renders
- [ ] Live preflight check against a Bedrock ARN with no env vars (expect fast-fail with hint)
- [ ] Live happy-path review against a Sonnet alias (expect preflight ~2-3s, then real run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)