### PR TITLE
Fix diff-mode returning empty changed files

### DIFF
--- a/scripts/security-review-action.py
+++ b/scripts/security-review-action.py
@@ -63,7 +63,7 @@ def get_changed_files(repo_dir: Path, diff_base: str) -> list[str]:
         return []
     try:
         result = subprocess.run(
-            ["git", "diff", "--name-only", "--diff-filter=ACMR", "--", diff_base],
+            ["git", "diff", "--name-only", "--diff-filter=ACMR", diff_base],
             capture_output=True, text=True, cwd=repo_dir,
             timeout=GIT_DIFF_TIMEOUT,
         )


### PR DESCRIPTION
## Summary
- `git diff --name-only --diff-filter=ACMR -- <sha>` treats `<sha>` as a path, not a ref — always returns empty
- Every PR- and push-triggered soundcheck run has been short-circuiting with 'No changed files. Nothing to review.'
- Drop the `--` so the SHA is parsed as a commit ref

## Test plan
- [x] `git diff --name-only --diff-filter=ACMR HEAD~1` returns the changed files (verified locally)
- [x] `git diff --name-only --diff-filter=ACMR -- HEAD~1` returns empty (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)