### PR TITLE
_claude_cli: surface stdout when claude -p fails with empty stderr

### DIFF
--- a/scripts/_claude_cli.py
+++ b/scripts/_claude_cli.py
@@ -97,8 +97,13 @@ def run_claude(
         cwd=cwd,
     )
     if result.returncode != 0:
+        # claude -p often writes its actual error to stdout (the response
+        # stream), not stderr — drop stdout into the message too when
+        # stderr is empty, otherwise diagnosing CI failures is impossible.
+        stderr_tail = (result.stderr or "").strip()
+        stdout_tail = (result.stdout or "").strip()
+        diag = stderr_tail or stdout_tail or "(no output)"
         raise ClaudeCLIError(
-            f"claude exited with code {result.returncode}: "
-            f"{result.stderr[:500]}"
+            f"claude exited with code {result.returncode}: {diag[:1000]}"
         )
     return result.stdout.strip() if result.stdout else ""


### PR DESCRIPTION
## Summary

\`claude -p\` writes both its response and its error diagnostics to **stdout** in \`--print\` mode. The wrapper was raising \`ClaudeCLIError\` with just \`stderr[:500]\`, which produces \"claude exited with code 1: \" (empty diag) on every failure mode we've seen in CI.

This patch prefers stderr when present, falls back to stdout, and uses \"(no output)\" when both are empty.

## Why

The soundcheck-action self-test has been failing silently on every run with \`ERROR: claude exited with code 1:\` and an empty trailing message. With this patch the next run will surface whatever \`claude -p\` is actually printing, which will tell us if it's an auth issue, a model-routing issue, a flag mismatch, or something else.

## Test plan

- [x] \`python scripts/validate-skills.py\` — 45/45 pass
- [ ] Land + bump soundcheck-action's SOUNDCHECK_SHA, then re-run the action self-test to see the real claude error

🤖 Generated with [Claude Code](https://claude.com/claude-code)