### PR TITLE
ci: verify auto-review-e2e workflow runs green

### DIFF
--- a/scripts/auto-review.py
+++ b/scripts/auto-review.py
@@ -299,3 +299,4 @@ def _main_locked(triage_only: bool) -> int:
 
 if __name__ == "__main__":
     sys.exit(main())
+# CI verification: triggers auto-review-e2e workflow.


### PR DESCRIPTION
No-op touch to \`scripts/auto-review.py\` to trigger the \`Auto-Review E2E\`
workflow path filter. Verifies the new workflow installs the claude CLI,
spins up fixture repos, and runs all four cases (A/B/C/D) green.

Will revert the no-op comment before merging — this PR is purely to
exercise CI wiring.